### PR TITLE
Showing the full path in Umbraco Relation Editor

### DIFF
--- a/Umbraco.RelationEditor.Tests/ConfigSerializationTests.cs
+++ b/Umbraco.RelationEditor.Tests/ConfigSerializationTests.cs
@@ -15,7 +15,7 @@ namespace Umbraco.RelationEditor.Tests
     [TestFixture]
     public class ConfigSerializationTests
     {
-        private const string Xml = @"<RelationEditor>
+        private const string XmlToolTip = @"<RelationEditor BreadCrumbMode=""ToolTip"" BreadCrumbSeparator=""/"">
   <ObjectType Alias=""page"" Name=""Document"">
     <EnabledRelation Alias=""pagePostRelation"">
       <EnabledChildType Alias=""post"" />
@@ -27,19 +27,21 @@ namespace Umbraco.RelationEditor.Tests
   </ObjectType>
 </RelationEditor>";
 
-        private const string BreadCrumbXml = @"<RelationEditor>
-  <ObjectType Alias=""page"" Name=""Document"" ShowBreadCrumb=""True"" BreadCrumbSeparator=""-&gt;"">
+        private const string XmlCaption = @"<RelationEditor BreadCrumbMode=""Caption"" BreadCrumbSeparator=""-&gt;"">
+  <ObjectType Alias=""page"" Name=""Document"">
     <EnabledRelation Alias=""pagePostRelation"">
       <EnabledChildType Alias=""post"" />
     </EnabledRelation>
     <EnabledRelation Alias=""pageNewsPostRelation"" />
   </ObjectType>
-  <ObjectType Alias=""post"" Name=""Document"" ShowBreadCrumb=""True"" BreadCrumbSeparator=""/"">
+  <ObjectType Alias=""post"" Name=""Document"">
     <EnabledRelation Alias=""pagePostRelation"" />
   </ObjectType>
 </RelationEditor>";
 
-        private const string Json = @"{
+        private const string JsonToolTip = @"{
+  ""BreadCrumbMode"": ""ToolTip"",
+  ""BreadCrumbSeparator"": ""/"",
   ""ObjectTypes"": [
     {
       ""Name"": ""Document"",
@@ -72,13 +74,13 @@ namespace Umbraco.RelationEditor.Tests
   ]
 }";
 
-        private const string BreadCrumbJson = @"{
+        private const string JsonCaption = @"{
+  ""BreadCrumbMode"": ""Caption"",
+  ""BreadCrumbSeparator"": ""->"",
   ""ObjectTypes"": [
     {
       ""Name"": ""Document"",
       ""Alias"": ""page"",
-      ""ShowBreadCrumb"": ""True"",
-      ""BreadCrumbSeparator"": ""->"",
       ""EnabledRelations"": [
         {
           ""Alias"": ""pagePostRelation"",
@@ -97,8 +99,6 @@ namespace Umbraco.RelationEditor.Tests
     {
       ""Name"": ""Document"",
       ""Alias"": ""post"",
-      ""ShowBreadCrumb"": ""True"",
-      ""BreadCrumbSeparator"": ""/"",
       ""EnabledRelations"": [
         {
           ""Alias"": ""pagePostRelation"",
@@ -112,7 +112,7 @@ namespace Umbraco.RelationEditor.Tests
         [Test]
         public void SerializeConfiguration()
         {
-            var config = CreateConfig();
+            var config = CreateToolTipConfig();
 
             var stringBuilder = new StringBuilder();
             var writer = new StringWriter(stringBuilder);
@@ -125,39 +125,39 @@ namespace Umbraco.RelationEditor.Tests
 
             Console.WriteLine(stringBuilder.ToString());
 
-            Assert.AreEqual(Xml, stringBuilder.ToString());
+            Assert.AreEqual(XmlToolTip, stringBuilder.ToString());
         }
 
         [Test]
         public void SerializeConfigurationAsJson()
         {
-            var config = CreateConfig();
+            var config = CreateToolTipConfig();
 
             var output = JsonConvert.SerializeObject(config, Formatting.Indented, new StringEnumConverter());
 
             Console.WriteLine(output);
 
-            Assert.AreEqual(Json, output);
+            Assert.AreEqual(JsonToolTip, output);
         }
 
         [Test]
-        public void DeserializeConfiguration()
+        public void DeserializeBreadCrumbToolTipConfiguration()
         {
-            var config = DeserializeFromInput();
-            AssertDeserialized(config);
+            var config = DeserializeFromBreadCrumbToolTipInput();
+            AssertBreadCrumbToolTipDeserialized(config);
         }
 
         [Test]
-        public void DeserializeConfigurationFromJson()
+        public void DeserializeBreadCrumbToolTipConfigurationFromJson()
         {
-            var config = JsonConvert.DeserializeObject<RelationEditorConfiguration>(Json, new StringEnumConverter());
-            AssertDeserialized(config);
+            var config = JsonConvert.DeserializeObject<RelationEditorConfiguration>(JsonToolTip, new StringEnumConverter());
+            AssertBreadCrumbToolTipDeserialized(config);
         }
 
         [Test]
-        public void SerializeBreadCrumbConfiguration()
+        public void SerializeBreadCrumbCaptionConfiguration()
         {
-            var config = CreateBreadCrumbConfig();
+            var config = CreateBreadCrumbCaptionConfig();
 
             var stringBuilder = new StringBuilder();
             var writer = new StringWriter(stringBuilder);
@@ -170,39 +170,39 @@ namespace Umbraco.RelationEditor.Tests
 
             Console.WriteLine(stringBuilder.ToString());
 
-            Assert.AreEqual(BreadCrumbXml, stringBuilder.ToString());
+            Assert.AreEqual(XmlCaption, stringBuilder.ToString());
         }
 
         [Test]
-        public void SerializeBreadCrumbConfigurationAsJson()
+        public void SerializeBreadCrumbCaptionConfigurationAsJson()
         {
-            var config = CreateBreadCrumbConfig();
+            var config = CreateBreadCrumbCaptionConfig();
 
             var output = JsonConvert.SerializeObject(config, Formatting.Indented, new StringEnumConverter());
 
             Console.WriteLine(output);
 
-            Assert.AreEqual(BreadCrumbJson, output);
+            Assert.AreEqual(JsonCaption, output);
         }
 
         [Test]
-        public void DeserializeBreadCrumbConfiguration()
+        public void DeserializeBreadCrumbCaptionConfiguration()
         {
-            var config = DeserializeFromBreadCrumbInput();
-            AssertBreadCrumbDeserialized(config);
+            var config = DeserializeFromBreadCrumbCaptionInput();
+            AssertBreadCrumbCaptionDeserialized(config);
         }
 
         [Test]
-        public void DeserializeBreadCrumbConfigurationFromJson()
+        public void DeserializeBreadCrumbCaptionConfigurationFromJson()
         {
-            var config = JsonConvert.DeserializeObject<RelationEditorConfiguration>(BreadCrumbJson, new StringEnumConverter());
-            AssertBreadCrumbDeserialized(config);
+            var config = JsonConvert.DeserializeObject<RelationEditorConfiguration>(JsonCaption, new StringEnumConverter());
+            AssertBreadCrumbCaptionDeserialized(config);
         }
 
         [Test]
         public void GetMethods()
         {
-            var config = DeserializeFromInput();
+            var config = DeserializeFromBreadCrumbToolTipInput();
             Assert.IsFalse(config.Get(UmbracoObjectTypes.Member, "").Enabled);
             Assert.IsTrue(config.Get(UmbracoObjectTypes.Document, "page").Enabled);
             Assert.IsFalse(config.Get(UmbracoObjectTypes.Document, "page").Get("invalidRelation").Enabled);
@@ -223,21 +223,27 @@ namespace Umbraco.RelationEditor.Tests
             Assert.AreEqual(UmbracoObjectTypes.Document, config.ObjectTypes[1].Name);
         }
 
-        private static void AssertBreadCrumbDeserialized(RelationEditorConfiguration config)
+        private static void AssertBreadCrumbCaptionDeserialized(RelationEditorConfiguration config)
         {
             AssertDeserialized(config);
 
-            Assert.AreEqual("->", config.ObjectTypes[0].BreadCrumbSeparator);
-            Assert.AreEqual("/", config.ObjectTypes[1].BreadCrumbSeparator);
-
-            Assert.IsTrue(config.ObjectTypes[0].ShowBreadCrumb.GetValueOrDefault(false));
-            Assert.IsTrue(config.ObjectTypes[1].ShowBreadCrumb.GetValueOrDefault(false));
+            Assert.AreEqual("->", config.BreadCrumbSeparator);
+            Assert.AreEqual(config.BreadCrumbMode,BreadCrumbMode.Caption);
         }
 
-        private static RelationEditorConfiguration CreateConfig()
+        private static void AssertBreadCrumbToolTipDeserialized(RelationEditorConfiguration config)
+        {
+            AssertDeserialized(config);
+
+            Assert.AreEqual("/", config.BreadCrumbSeparator);
+            Assert.AreEqual(config.BreadCrumbMode, BreadCrumbMode.ToolTip);
+        }
+
+        private static RelationEditorConfiguration CreateToolTipConfig()
         {
             var config = new RelationEditorConfiguration
             {
+                BreadCrumbSeparator = "/",
                 ObjectTypes = new List<ObjectTypeConfiguration>
                 {
                     new ObjectTypeConfiguration
@@ -274,27 +280,26 @@ namespace Umbraco.RelationEditor.Tests
             return config;
         }
 
-        private static RelationEditorConfiguration CreateBreadCrumbConfig()
+        private static RelationEditorConfiguration CreateBreadCrumbCaptionConfig()
         {
-            var config = CreateConfig();
-            config.ObjectTypes.ForEach(x => { x.ShowBreadCrumb = true; x.BreadCrumbSeparator = "->";});
-            config.ObjectTypes[0].BreadCrumbSeparator = "->";
-            config.ObjectTypes[1].BreadCrumbSeparator = "/";
+            var config = CreateToolTipConfig();
+            config.BreadCrumbMode = BreadCrumbMode.Caption;
+            config.BreadCrumbSeparator = "->";
             return config;
         }
 
-        private static RelationEditorConfiguration DeserializeFromInput()
+        private static RelationEditorConfiguration DeserializeFromBreadCrumbToolTipInput()
         {
             var serializer = new XmlSerializer(typeof(RelationEditorConfiguration));
-            var reader = new StringReader(Xml);
+            var reader = new StringReader(XmlToolTip);
             var config = (RelationEditorConfiguration)serializer.Deserialize(reader);
             return config;
         }
 
-        private static RelationEditorConfiguration DeserializeFromBreadCrumbInput()
+        private static RelationEditorConfiguration DeserializeFromBreadCrumbCaptionInput()
         {
             var serializer = new XmlSerializer(typeof(RelationEditorConfiguration));
-            var reader = new StringReader(BreadCrumbXml);
+            var reader = new StringReader(XmlCaption);
             var config = (RelationEditorConfiguration)serializer.Deserialize(reader);
             return config;
         }

--- a/Umbraco.RelationEditor.Tests/ConfigSerializationTests.cs
+++ b/Umbraco.RelationEditor.Tests/ConfigSerializationTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;

--- a/Umbraco.RelationEditor.Web/App_Plugins/RelationEditor/editrelations.html
+++ b/Umbraco.RelationEditor.Web/App_Plugins/RelationEditor/editrelations.html
@@ -20,7 +20,7 @@
                         <tr ng-repeat="relation in resourceSet.Relations" ng-show="isActive(relation)">
                             <td style="width:5%;" class="direction"></td>
                             <td style="width:15%;">{{relation.ChildId}}</td>
-                            <td style="width:70%;">{{relation.ChildName}}</td>
+                            <td style="width:70%;" title="{{relation.FullPath}}">{{relation.ChildName}}</td>
                             <td style="width:10%;"><button class="btn btn-danger" ng-click="remove(relation)">Remove</button></td>
                         </tr>
                     </tbody>

--- a/Umbraco.RelationEditor.Web/config/RelationEditor.config
+++ b/Umbraco.RelationEditor.Web/config/RelationEditor.config
@@ -1,5 +1,5 @@
 ﻿<RelationEditor>
-  <ObjectType Name="Document" Alias="page">
+  <ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
     <EnabledRelation Alias="documentRelation">
       <EnabledChildType Alias="post"/>
     </EnabledRelation>

--- a/Umbraco.RelationEditor.Web/config/RelationEditor.config
+++ b/Umbraco.RelationEditor.Web/config/RelationEditor.config
@@ -1,5 +1,5 @@
-﻿<RelationEditor>
-  <ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
+﻿<RelationEditor BreadCrumbMode="ToolTip" BreadCrumbSeparator="/">
+  <ObjectType Name="Document" Alias="page">
     <EnabledRelation Alias="documentRelation">
       <EnabledChildType Alias="post"/>
     </EnabledRelation>

--- a/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
+++ b/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
@@ -40,8 +40,8 @@ If no enabled child types are enabled, all types will be selectable.
 Note: Names and aliases are case sensitive.
 
 Here's a sample configuration:
-<RelationEditor>
-  <ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
+<RelationEditor BreadCrumbMode="ToolTip" BreadCrumbSeparator="/">
+  <ObjectType Name="Document" Alias="page">
     <EnabledRelation Alias="documentRelation">
       <EnabledChildType Alias="post"/>
     </EnabledRelation>

--- a/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
+++ b/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
@@ -17,14 +17,14 @@ Supported relation types are
 * MediaType -> DocumentType
 * MediaType -> MediaType
 
+Document and Media have the option to display the entire path, with a separator
+<RelationEditor BreadCrumbMode="Caption" BreadCrumbSeparator="/">
+The above resolves to something like
+Home / Site 1 / Page 1
+
 Document and Media need a specified Alias to be enabled.
 Alias is the alias of the respective type.
 IE. <ObjectType Name="Document" Alias="myDocumentTypeAlias">
-
-Document and Media have the option to display the entire path, with a separator
-<ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
-The above resolves to something like
-Home / Site 1 / Page 1
 
 Types does not need, nor should have alias.
 IE. <ObjectType Name="DocumentType"/>

--- a/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
+++ b/Umbraco.RelationEditor.Web/config/relationeditor.sample.config
@@ -21,6 +21,11 @@ Document and Media need a specified Alias to be enabled.
 Alias is the alias of the respective type.
 IE. <ObjectType Name="Document" Alias="myDocumentTypeAlias">
 
+Document and Media have the option to display the entire path, with a separator
+<ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
+The above resolves to something like
+Home / Site 1 / Page 1
+
 Types does not need, nor should have alias.
 IE. <ObjectType Name="DocumentType"/>
 
@@ -36,7 +41,7 @@ Note: Names and aliases are case sensitive.
 
 Here's a sample configuration:
 <RelationEditor>
-  <ObjectType Name="Document" Alias="page">
+  <ObjectType Name="Document" Alias="page" ShowBreadCrumb="True" BreadCrumbSeparator="/">
     <EnabledRelation Alias="documentRelation">
       <EnabledChildType Alias="post"/>
     </EnabledRelation>

--- a/Umbraco.RelationEditor/Configuration.cs
+++ b/Umbraco.RelationEditor/Configuration.cs
@@ -54,7 +54,7 @@ namespace Umbraco.RelationEditor
         public bool? ShowBreadCrumb;
 
         [XmlAttribute("ShowBreadCrumb")]
-        [JsonProperty("ShowBreadCrumb", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("ShowBreadCrumb", NullValueHandling = NullValueHandling.Ignore, Order = 3)]
         public string StrShowBreadCrumb
         {
             get { return (ShowBreadCrumb.HasValue) ? ShowBreadCrumb.ToString() : null; }
@@ -62,11 +62,11 @@ namespace Umbraco.RelationEditor
         }
 
         [XmlAttribute]
-        [JsonProperty("BreadCrumbSeparator", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("BreadCrumbSeparator", NullValueHandling = NullValueHandling.Ignore, Order = 4)]
         public string BreadCrumbSeparator { get; set; }
 
         [XmlElement("EnabledRelation")]
-        [JsonProperty(Order = 3)]
+        [JsonProperty(Order = 5)]
         public List<EnabledRelationConfiguration> EnabledRelations { get; set; }
 
         public EnabledRelationConfiguration Get(string alias)

--- a/Umbraco.RelationEditor/Configuration.cs
+++ b/Umbraco.RelationEditor/Configuration.cs
@@ -48,6 +48,23 @@ namespace Umbraco.RelationEditor
         [XmlAttribute]
         [JsonProperty(Order = 1)]
         public UmbracoObjectTypes Name { get; set; }
+
+        [XmlIgnore]
+        [JsonIgnore]
+        public bool? ShowBreadCrumb;
+
+        [XmlAttribute("ShowBreadCrumb")]
+        [JsonProperty("ShowBreadCrumb", NullValueHandling = NullValueHandling.Ignore)]
+        public string StrShowBreadCrumb
+        {
+            get { return (ShowBreadCrumb.HasValue) ? ShowBreadCrumb.ToString() : null; }
+            set { ShowBreadCrumb = !string.IsNullOrEmpty(value) ? bool.Parse(value) : default(bool?); }
+        }
+
+        [XmlAttribute]
+        [JsonProperty("BreadCrumbSeparator", NullValueHandling = NullValueHandling.Ignore)]
+        public string BreadCrumbSeparator { get; set; }
+
         [XmlElement("EnabledRelation")]
         [JsonProperty(Order = 3)]
         public List<EnabledRelationConfiguration> EnabledRelations { get; set; }

--- a/Umbraco.RelationEditor/Configuration.cs
+++ b/Umbraco.RelationEditor/Configuration.cs
@@ -27,6 +27,22 @@ namespace Umbraco.RelationEditor
     [XmlRoot("RelationEditor")]
     public class RelationEditorConfiguration
     {
+        [XmlIgnore]
+        [JsonIgnore]
+        public BreadCrumbMode BreadCrumbMode;
+
+        [XmlAttribute("BreadCrumbMode")]
+        [JsonProperty("BreadCrumbMode", NullValueHandling = NullValueHandling.Ignore)]
+        public string StrBreadCrumbMode
+        {
+            get { return BreadCrumbMode.ToString(); }
+            set { BreadCrumbMode = Enum.IsDefined(typeof(BreadCrumbMode), value) ? (BreadCrumbMode)Enum.Parse(typeof(BreadCrumbMode), value) : BreadCrumbMode.ToolTip; }
+        }
+
+        [XmlAttribute]
+        [JsonProperty("BreadCrumbSeparator", NullValueHandling = NullValueHandling.Ignore)]
+        public string BreadCrumbSeparator { get; set; }
+        
         [XmlElement("ObjectType")]
         public List<ObjectTypeConfiguration> ObjectTypes { get; set; }
 
@@ -48,23 +64,7 @@ namespace Umbraco.RelationEditor
         [XmlAttribute]
         [JsonProperty(Order = 1)]
         public UmbracoObjectTypes Name { get; set; }
-
-        [XmlIgnore]
-        [JsonIgnore]
-        public bool? ShowBreadCrumb;
-
-        [XmlAttribute("ShowBreadCrumb")]
-        [JsonProperty("ShowBreadCrumb", NullValueHandling = NullValueHandling.Ignore, Order = 3)]
-        public string StrShowBreadCrumb
-        {
-            get { return (ShowBreadCrumb.HasValue) ? ShowBreadCrumb.ToString() : null; }
-            set { ShowBreadCrumb = !string.IsNullOrEmpty(value) ? bool.Parse(value) : default(bool?); }
-        }
-
-        [XmlAttribute]
-        [JsonProperty("BreadCrumbSeparator", NullValueHandling = NullValueHandling.Ignore, Order = 4)]
-        public string BreadCrumbSeparator { get; set; }
-
+        
         [XmlElement("EnabledRelation")]
         [JsonProperty(Order = 5)]
         public List<EnabledRelationConfiguration> EnabledRelations { get; set; }
@@ -149,5 +149,11 @@ namespace Umbraco.RelationEditor
                 }
             }
         }
+    }
+
+    public enum BreadCrumbMode
+    {
+        ToolTip,
+        Caption
     }
 }

--- a/Umbraco.RelationEditor/Configuration.cs
+++ b/Umbraco.RelationEditor/Configuration.cs
@@ -112,14 +112,14 @@ namespace Umbraco.RelationEditor
 
     public class Configuration
     {
-        private static RelationEditorConfiguration configuration = null;
+        public static RelationEditorConfiguration Config = null;
 
         private static IEnumerable<ObjectTypeConfiguration> ObjectTypes
         {
             get
             {
                 EnsureConfiguration();
-                return configuration.ObjectTypes;
+                return Config.ObjectTypes;
             }
         }
 
@@ -132,20 +132,20 @@ namespace Umbraco.RelationEditor
 
         private static void EnsureConfiguration()
         {
-            if (configuration == null)
+            if (Config == null)
             {
                 try
                 {
                     var serializer = new XmlSerializer(typeof (RelationEditorConfiguration));
                     using (var reader = new StreamReader(HttpContext.Current.Server.MapPath("~/config/RelationEditor.config")))
                     { 
-                        configuration = (RelationEditorConfiguration) serializer.Deserialize(reader);
+                        Config = (RelationEditorConfiguration) serializer.Deserialize(reader);
                     }
                 }
                 catch(Exception ex)
                 {
                     LogHelper.Error<Configuration>("Could not read config/RelationEditor.config", ex);
-                    configuration = new RelationEditorConfiguration();
+                    Config = new RelationEditorConfiguration();
                 }
             }
         }

--- a/Umbraco.RelationEditor/Controllers/RelationsController.cs
+++ b/Umbraco.RelationEditor/Controllers/RelationsController.cs
@@ -160,7 +160,9 @@ namespace Umbraco.RelationEditor.Controllers
             switch (UmbracoObjectTypesExtensions.GetUmbracoObjectType(childObjectType))
             {
                 case UmbracoObjectTypes.Document:
-                    return contentService.GetById(childId).Name;
+                    var node = contentService.GetById(childId);
+                    var ancestors = String.Join(" / ", contentService.GetById(childId).Ancestors().Select(x => x.Name));
+                    return string.Concat(ancestors, " / " , node.Name);
                 case UmbracoObjectTypes.Media:
                     return mediaService.GetById(childId).Name;
                 case UmbracoObjectTypes.DocumentType:

--- a/Umbraco.RelationEditor/Controllers/RelationsController.cs
+++ b/Umbraco.RelationEditor/Controllers/RelationsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Umbraco.Core.Models;
@@ -55,7 +56,7 @@ namespace Umbraco.RelationEditor.Controllers
             object alias;
             entity.AdditionalData.TryGetValue("Alias", out alias);
             var typeConfig = RelationEditor.Configuration.Get(fromType, alias as string);
-
+            var config = RelationEditor.Configuration.Config;
             var allRelations = relationService.GetByParentOrChildId(parentId);
             var allowedObjectTypes = Mappings.AllowedRelations[fromType];
             var enabledRelations = typeConfig.EnabledRelations.Select(r => r.Alias).ToArray();
@@ -81,7 +82,6 @@ namespace Umbraco.RelationEditor.Controllers
                         {
                             int otherId;
                             string otherName, fullPath;
-                            var config = RelationEditor.Configuration.Config;
                             if (r.ParentId == parentId)
                             {
                                 otherId = r.ChildId;
@@ -96,8 +96,8 @@ namespace Umbraco.RelationEditor.Controllers
                             return new RelationDto
                             {
                                 ChildId = otherId,
-                                ChildName = otherName,
-                                FullPath = fullPath,
+                                FullPath = HttpContext.Current.Server.HtmlEncode(fullPath),
+                                ChildName = (config.BreadCrumbMode == BreadCrumbMode.ToolTip) ? otherName : HttpContext.Current.Server.HtmlDecode(fullPath),
                                 State = RelationStateEnum.Unmodified
                             };
                         }).ToList()
@@ -175,11 +175,13 @@ namespace Umbraco.RelationEditor.Controllers
                     return mediaNode.Name;
 
                 case UmbracoObjectTypes.DocumentType:
-                    fullPath = "";
-                    return contentTypeService.GetContentType(childId).Name;
+                    // not going to use paths for Document Type
+                    fullPath = contentTypeService.GetContentType(childId).Name;
+                    return fullPath;
                 case UmbracoObjectTypes.MediaType:
-                    fullPath = "";
-                    return contentTypeService.GetMediaType(childId).Name;
+                    // not going to use paths for Document Type
+                    fullPath = contentTypeService.GetMediaType(childId).Name;
+                    return fullPath;
             }
             throw new Exception("Unknown child type");
         }


### PR DESCRIPTION
- option of using a separator character of choice in configuration
- option to show the full path of the item that is located, instead of just the name
- backward compatibility to a standard configuration file for sites who do not wish to take advantage of the two features above.