### PR TITLE
Error when creating document type within a document type folder

### DIFF
--- a/Umbraco.RelationEditor/Controllers/RelationsController.cs
+++ b/Umbraco.RelationEditor/Controllers/RelationsController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.EntityBase;
 using Umbraco.Core.Services;
@@ -161,6 +162,10 @@ namespace Umbraco.RelationEditor.Controllers
             {
                 var objectType = Mappings.TreeNodeObjectTypes[treeNodeType];
                 var alias = EntityHelper.FindAlias(objectType, id);
+                if (alias.IsNullOrWhiteSpace())
+                {
+                    return new IsAllowedResult(false);
+                }
                 return new IsAllowedResult(relConfig.Get(alias).Enabled);
             }
             return new IsAllowedResult(false);

--- a/Umbraco.RelationEditor/EntityHelper.cs
+++ b/Umbraco.RelationEditor/EntityHelper.cs
@@ -6,8 +6,12 @@ static internal class EntityHelper
     public static string FindAlias(UmbracoObjectTypes objectType, int id)
     {
         var item = UmbracoContext.Current.Application.Services.EntityService.Get(id, objectType);
-        object alias = null;
-        item.AdditionalData.TryGetValue("Alias", out alias);
-        return alias as string;
+        if (item != null){
+            object alias = null;
+            item.AdditionalData.TryGetValue("Alias", out alias);
+            return alias as string;
+        } else {
+            return null;
+        }
     }
 }

--- a/Umbraco.RelationEditor/RelationEditorEvents.cs
+++ b/Umbraco.RelationEditor/RelationEditorEvents.cs
@@ -52,7 +52,7 @@ namespace Umbraco.RelationEditor
                 {
                     var id = Convert.ToInt32(node.Id);
                     var alias = EntityHelper.FindAlias(childObjectType, id);
-                    if (!childTypes.Contains(alias, IgnoreCase))
+                    if (!alias.IsNullOrWhiteSpace() && !childTypes.Contains(alias, IgnoreCase))
                     {
                         node.SetNotPublishedStyle();
                         node.AdditionalData.Add("relationDisallowed", "true");


### PR DESCRIPTION
An error of "object reference not set to an instance" occurs in the back-office.