### PR TITLE
GetApplicationTree returned 400 Bad Request

### DIFF
--- a/Umbraco.RelationEditor.Web/App_Plugins/RelationEditor/relationeditor.js
+++ b/Umbraco.RelationEditor.Web/App_Plugins/RelationEditor/relationeditor.js
@@ -72,7 +72,8 @@
                     relationEditor: true,
                     parentType: $scope.data.ParentType,
                     parentTypeAlias: $scope.data.ParentAlias,
-                    relationAlias: $scope.resourceSets[index].Alias
+                    relationAlias: $scope.resourceSets[index].Alias,
+                    onlyInitialized: false
                 }),
                 treeAlias: $scope.resourceSets[index].ChildType.TreeType,
                 section: $scope.resourceSets[index].ChildType.Section,


### PR DESCRIPTION
With Umbraco version 7.6.4 the request to umbraco/backoffice/UmbracoTrees/ApplicationTree/GetApplicationTrees returned error 400 bad request. 
The parameters dictionary contains a null entry for parameter 'onlyInitialized' of non-nullable type 'System.Boolean' for method 'System.Threading.Tasks.Task`1[Umbraco.Web.Models.Trees.SectionRootNode] GetApplicationTrees(System.String, System.String, System.Net.Http.Formatting.FormDataCollection, Boolean)' in 'Umbraco.Web.Trees.ApplicationTreeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
Adding extra parameter onlyInitialized solved this issue.